### PR TITLE
docs : fix incorrect link of Project Specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 ## batch-10-tripen
 	
 ### Project Specs
-- [Notion](https://www.notion.so/pesto/Batch-8-Project-Specs-33ef6ae26565459f98771b95c7f0cecd)
+- [Notion](https://www.notion.so/Batch-10-specs-d18972b6307b405380a294896f2b0899)
 
 ### Instructions
-- Please create a issue first and then attach that issue to the PR, so that every one know what’s the need of the PR. Attaching issues to the PR using github keywords, will close the issues once the PR is merged. More info [here]((https://help.github.com/en/articles/closing-issues-using-keywords)).
+- Please create an issue first and then attach that issue to the PR, so that everyone knows what’s the need of the PR. Attaching issues to the PR using Github keywords will close the issues once the PR is merged. More info [here]((https://help.github.com/en/articles/closing-issues-using-keywords)).
 
 - Please follow a common git commit style guide. Somewhat similar to [this guide](https://udacity.github.io/git-styleguide/)
 
 - All PRs should be [Rebase And Merged](https://help.github.com/en/articles/about-pull-request-merges#rebase-and-merge-your-pull-request-commits)
 
-### Some of the points to keep in point
-- Every thing should be visible at the end of day (Golden rule)
-- Architecture - create architecture of the program before starting it, lay down all the entities. Define CRUD operations for these entities, create components around these entities.
-- GitHub - create guidelines for commit messages. Create separate environment for staging and production. Always rebase your branch. Every pull request should solve an single issue. Issue must be created before any pull request and should be closed after the issue is fixed. All discussions should be done on issues.
-- Slack - Every day standups, weekly loom videos, no private messages conversation, always be in public so that any one can improve or put his points into the arguments.
-- Testing - follow tdd as much as possible. There is no need for tests for presentational components, tesrs are only required for container components
+### Some of the points to keep in mind
+- Everything should be visible at the end of the day (Golden rule).
+- Architecture - create an architecture of the program before starting it, lay down all the entities. Define CRUD operations for these entities, create components around these entities.
+- GitHub - create guidelines for commit messages. Create a separate environment for staging and production. Always rebase your branch. Every pull request should solve a single issue. The issue must be created before any pull request and should be closed after the issue is fixed. All discussions should be done on issues.
+- Slack - Everyday standups, weekly loom videos, no private messages conversation, always be in public so that anyone can improve or put his points into the arguments.
+- Testing - Follow TDD as much as possible. There is no need for tests for presentational components, tests are only required for container components.
 - Latest and stable - like Babel, import/ export, class variables.
 - Documentation (on README)
-- Abstraction- things which are common throuhout the app should be abstracted like buttons, forms, inputs
-- Gifs/ video for frontend prs.
-- Review each other PRs.
-- don’t commit in someone else pr
+- Abstraction- things which are common throughout the app should be abstracted like buttons, forms, inputs
+- Gifs/ video for frontend PRs.
+- Review each others PR.
+- Don’t commit in someone else PR
   


### PR DESCRIPTION
fix: #24

## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/pesto-students/batch-10-tripen/wiki/Commit-message-guidelines)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] GIFs/Videos/Images added (compulsory for frontend changes)

## PR Type
What kind of change does this PR introduce? 

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
= [ ] Tests changed / added / updated
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Infrastructure changes
- [ ] Dependency upgrade
- [ ] Other... Please describe:

## Issue Number: 
#24

## What is the new behavior?
Project Link now redirects to batch-10 project specs

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information