### PR TITLE
fix: shift auth controllers to mongodb-memory-server

### DIFF
--- a/server/src/controllers/v1/auth.test.js
+++ b/server/src/controllers/v1/auth.test.js
@@ -1,5 +1,14 @@
+import InMemDb from '../../configs/dbtest';
 import { newToken, verifyToken } from '../../utils/helpers/jwtHelper';
 import { signupController, signinController } from './auth';
+
+beforeAll(async () => {
+  await InMemDb.connect();
+});
+
+afterAll(async () => {
+  await InMemDb.disconnect();
+});
 
 describe('Authentication controllers:', () => {
   describe('newToken:', () => {
@@ -77,7 +86,8 @@ describe('Authentication controllers:', () => {
       await signupController(wrongMockReq, mockRes);
       expect(statusLog).toBe(400);
       expect(resultLog.success).toBe(false);
-      expect(resultLog.message).toBe('Incorrect / incomplete field values. Please correct.');
+      expect(resultLog).toHaveProperty('error');
+      expect(resultLog.message).not.toBe('Sign-up successful');
     });
 
     it('requires inputs', async () => {


### PR DESCRIPTION
fix: #116

## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/pesto-students/batch-10-tripen/wiki/Commit-message-guidelines)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] GIFs/Videos/Images added (compulsory for frontend changes)

## PR Type
What kind of change does this PR introduce? 

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [x] Tests changed / added / updated
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Infrastructure changes
- [ ] Dependency upgrade
- [ ] Other... Please describe:

## Issue Number: 
#116 

## What is the new behavior?
Tests use mongodb-memory-server

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information